### PR TITLE
Refactor Assassin click handling

### DIFF
--- a/src/classes/PlayerClasses/PC_Assassin.ts
+++ b/src/classes/PlayerClasses/PC_Assassin.ts
@@ -13,20 +13,27 @@ export class PC_Assassin extends Player {
 		this.maxHealth = this.health;
 	}
 
-	public override onSecondaryAction(cell: Cell, e: MouseEvent): void {
-		e.preventDefault();
-		if (!cell.isClicked) {
-			cell.activateCell(0);
+        public override onPrimaryAction(cell: Cell, e?: MouseEvent): void {
+                if (e && e.detail === 2) {
+                        if (!cell.isClicked) {
+                                cell.activateCell(0);
 
-			if (this.level === cell.type || (cell.type === CellType.Boss && this.level >= 5)) {
-				cell.attackPlayer(0);
-			} else if (this.level < cell.type) {
-				cell.attackPlayer();
-			} else {
-				cell.attackPlayer(1);
-			}
-		} else {
-			cell.clickNeighbors();
-		}
-	}
+                                if (this.level === cell.type || (cell.type === CellType.Boss && this.level >= 5)) {
+                                        cell.attackPlayer(0);
+                                } else if (this.level < cell.type) {
+                                        cell.attackPlayer();
+                                } else {
+                                        cell.attackPlayer(1);
+                                }
+                        } else {
+                                cell.clickNeighbors();
+                        }
+                } else {
+                        super.onPrimaryAction(cell, e);
+                }
+        }
+
+        public override onSecondaryAction(cell: Cell, e: MouseEvent): void {
+                super.onSecondaryAction(cell, e);
+        }
 }

--- a/src/classes/PlayerClasses/PC_Mage.ts
+++ b/src/classes/PlayerClasses/PC_Mage.ts
@@ -38,13 +38,13 @@ export class PC_Mage extends Player {
 		}
 	}
 
-	override onPrimaryAction(cell: Cell): void {
-		if (this.isFireballModeActive) {
-			this.castFireballOnCell(cell.x, cell.y);
-		} else {
-			super.onPrimaryAction(cell);
-		}
-	}
+        override onPrimaryAction(cell: Cell, e?: MouseEvent): void {
+                if (this.isFireballModeActive) {
+                        this.castFireballOnCell(cell.x, cell.y);
+                } else {
+                        super.onPrimaryAction(cell, e);
+                }
+        }
 
 	public canCastFireball(): boolean {
 		return this._fireballAvailable;

--- a/src/classes/board.ts
+++ b/src/classes/board.ts
@@ -267,11 +267,11 @@ export class Board {
 
 			if (e.button === 0) {
 				// Normal left click
-				if (this.gameInstance.invertClicks) {
-					this.gameInstance.player.onSecondaryAction(clickedCell, e);
-				} else {
-					this.gameInstance.player.onPrimaryAction(clickedCell);
-				}
+                                if (this.gameInstance.invertClicks) {
+                                        this.gameInstance.player.onSecondaryAction(clickedCell, e);
+                                } else {
+                                        this.gameInstance.player.onPrimaryAction(clickedCell, e);
+                                }
 			}
 		};
 	}
@@ -283,11 +283,11 @@ export class Board {
 			if (!target.dataset.x || !target.dataset.y) return;
 			const clickedCell = this.cells[Number(target.dataset.x)][Number(target.dataset.y)];
 
-			if (this.gameInstance.invertClicks) {
-				this.gameInstance.player.onPrimaryAction(clickedCell);
-			} else {
-				this.gameInstance.player.onSecondaryAction(clickedCell, e);
-			}
+                        if (this.gameInstance.invertClicks) {
+                                this.gameInstance.player.onPrimaryAction(clickedCell, e);
+                        } else {
+                                this.gameInstance.player.onSecondaryAction(clickedCell, e);
+                        }
 		};
 	}
 

--- a/src/classes/player.ts
+++ b/src/classes/player.ts
@@ -68,9 +68,9 @@ export abstract class Player {
 	/*==============*/
 	/*public methods*/
 	/*==============*/
-	public onPrimaryAction(cell: Cell): void {
-		cell.click();
-	}
+        public onPrimaryAction(cell: Cell, _e?: MouseEvent): void {
+                cell.click();
+        }
 
 	public onSecondaryAction(cell: Cell, e: MouseEvent): void {
 		cell.rightClick(e);


### PR DESCRIPTION
## Summary
- Move Assassin's defeat ability to double-click primary action
- Restore right-click flagging for Assassin and other classes
- Pass click event to player primary actions and update Mage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6896503c4ce08330beebb4ee54f10e42