### PR TITLE
Enable double-click assassin ability

### DIFF
--- a/src/classes/PlayerClasses/PC_Assassin.ts
+++ b/src/classes/PlayerClasses/PC_Assassin.ts
@@ -13,10 +13,10 @@ export class PC_Assassin extends Player {
 		this.maxHealth = this.health;
 	}
 
-        public override onPrimaryAction(cell: Cell, e?: MouseEvent): void {
-                if (e && e.detail === 2) {
-                        if (!cell.isClicked) {
-                                cell.activateCell(0);
+       public override onPrimaryAction(cell: Cell, e?: MouseEvent): void {
+               if (e && (e.detail === 2 || e.type === "dblclick")) {
+                       if (!cell.isClicked) {
+                               cell.activateCell(0);
 
                                 if (this.level === cell.type || (cell.type === CellType.Boss && this.level >= 5)) {
                                         cell.attackPlayer(0);


### PR DESCRIPTION
## Summary
- Detect double clicks at board level and always route them to the primary action
- Trigger assassin's execute ability on double-click events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896660464d0833098246c54e53ab2ee